### PR TITLE
Add expected yields to apiary etc

### DIFF
--- a/src/main/java/tterrag/wailaplugins/plugins/PluginForestry.java
+++ b/src/main/java/tterrag/wailaplugins/plugins/PluginForestry.java
@@ -205,6 +205,14 @@ public class PluginForestry extends PluginBase {
                                     EnumChatFormatting.AQUA + pctFmt.format(tag.getDouble(BREED_PROGRESS))));
                 }
             }
+
+            if (tag.hasKey(IS_JUBILANT)) {
+                if (tag.getBoolean(IS_JUBILANT)) {
+                    currenttip.add(EnumChatFormatting.AQUA + lang.localize("isJubilant"));
+                } else {
+                    currenttip.add(EnumChatFormatting.RED + lang.localize("isNotJubilant"));
+                }
+            }
         }
     }
 
@@ -295,7 +303,8 @@ public class PluginForestry extends PluginBase {
             for (Map.Entry<Float, ItemStack[]> ent : productsByYield.descendingMap().entrySet()) {
                 String name = ent.getValue()[0].getDisplayName();
                 boolean isDup = ent.getValue().length > 1;
-                String namePart = name + (isDup ? "... : " : ": ");
+                String namePart = name + (isDup ? ", ... : " : ": ");
+                // items / bee tick * 60 seconds / minute * 60 minutes / hour / (27.5 seconds / bee tick) = items / hour
                 String yieldPart = String.format("%.3f ", ent.getKey() * 60 * 60 / 27.5)
                         + lang.localize("yieldPerHour");
                 currenttip.add(SpecialChars.TAB + namePart + yieldPart);
@@ -308,6 +317,7 @@ public class PluginForestry extends PluginBase {
     public static final String DRONE_STACK = "droneStack";
     public static final String PROD_MOD = "dummyProduction";
     public static final String ERRORS = "errors";
+    public static final String IS_JUBILANT = "isJubilant";
     public static final String BREED_PROGRESS = "breedProgress";
     public static final String TREE = "treeData";
     public static final String ENERGY_STORED = "rfStored";
@@ -371,6 +381,11 @@ public class PluginForestry extends PluginBase {
                             .getProductionModifier(genome, prodMod);
 
                     tag.setFloat(PROD_MOD, prodMod);
+
+                    tag.setBoolean(
+                            IS_JUBILANT,
+                            genome.getPrimary().isJubilant(genome, housing)
+                                    && genome.getSecondary().isJubilant(genome, housing));
                 }
             }
         }

--- a/src/main/java/tterrag/wailaplugins/plugins/PluginForestry.java
+++ b/src/main/java/tterrag/wailaplugins/plugins/PluginForestry.java
@@ -3,13 +3,17 @@ package tterrag.wailaplugins.plugins;
 import java.lang.reflect.Field;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MovingObjectPosition;
@@ -178,11 +182,17 @@ public class PluginForestry extends PluginBase {
             }
 
             if (tag.hasKey(DUMMY_PRODUCTION)) {
+                EnumChatFormatting color = (tag.hasKey(IS_OVERWORKED) && !tag.getBoolean(IS_OVERWORKED))
+                        ? EnumChatFormatting.AQUA
+                        : EnumChatFormatting.RED;
                 currenttip.add(
                         EnumChatFormatting.WHITE + lang.localize(
                                 "effectiveProductionMul",
-                                EnumChatFormatting.AQUA
-                                        + String.format("b^0.52 * %.3f", tag.getFloat(DUMMY_PRODUCTION))));
+                                color + String.format("b^0.52 * %.3f", tag.getFloat(DUMMY_PRODUCTION))));
+            }
+
+            if (tag.hasKey(BEE_YIELD)) {
+                addBeeYieldInfo(tag.getTagList(BEE_YIELD, 10), currenttip);
             }
 
             if (tag.hasKey(ERRORS) || tag.hasKey(BREED_PROGRESS)) {
@@ -255,10 +265,40 @@ public class PluginForestry extends PluginBase {
         }
     }
 
+    private void extendBeeYieldMap(Map<ItemStack, Float> yields, Map<ItemStack, Float> products, boolean isSecondary,
+            float speed, float prodMod, float t) {
+        for (Map.Entry<ItemStack, Float> product : products.entrySet()) {
+            float chance = product.getValue() / (isSecondary ? 2f : 1f);
+            float term = Math.min(Bee.getFinalChance(chance, speed, prodMod, t), 1f);
+            if (yields.computeIfPresent(product.getKey(), (k, v) -> v + term) == null) {
+                yields.put(product.getKey(), term);
+            }
+        }
+    }
+
+    private void addBeeYieldInfo(NBTTagList tagList, List<String> currenttip) {
+        if (Proxies.common.isShiftDown()) {
+            for (int i = 0; i < tagList.tagCount(); ++i) {
+                NBTTagCompound entTag = tagList.getCompoundTagAt(i);
+                String namePart = lang.localize(entTag.getString("name"));
+                if (entTag.getBoolean("dup")) {
+                    namePart += "... : ";
+                } else {
+                    namePart += ": ";
+                }
+                String yieldPart = String.format("%.3f ", entTag.getFloat("yield") * 60 * 60 / 27.5)
+                        + lang.localize("yieldPerHour");
+                currenttip.add(SpecialChars.TAB + namePart + yieldPart);
+            }
+        }
+    }
+
     public static final String LEAF_BRED_SPECIES = "leafBredSpecies";
     public static final String QUEEN_STACK = "queenStack";
     public static final String DRONE_STACK = "droneStack";
     public static final String DUMMY_PRODUCTION = "dummyProduction";
+    public static final String IS_OVERWORKED = "isOverworked";
+    public static final String BEE_YIELD = "beeYield";
     public static final String ERRORS = "errors";
     public static final String BREED_PROGRESS = "breedProgress";
     public static final String TREE = "treeData";
@@ -321,9 +361,41 @@ public class PluginForestry extends PluginBase {
                             .getProductionModifier(genome, 0f);
                     prodMod += BeeManager.beeRoot.getBeekeepingMode(housing.getWorld()).getBeeModifier()
                             .getProductionModifier(genome, prodMod);
-                    float dummyProd = 100f * Bee.getFinalChance(0.01f, genome.getSpeed(), prodMod, 1f);
+                    float speed = genome.getSpeed();
+                    float dummyProd = 100f * Math.min(Bee.getFinalChance(0.01f, speed, prodMod, 1f), 1f);
 
                     tag.setFloat(DUMMY_PRODUCTION, dummyProd);
+                    tag.setBoolean(IS_OVERWORKED, prodMod > 16f);
+
+                    // create a summary of the average yields for all outputs with different average yields
+                    Map<ItemStack, Float> yields = new HashMap<>();
+                    extendBeeYieldMap(yields, genome.getPrimary().getProductChances(), false, speed, prodMod, 1f);
+                    extendBeeYieldMap(yields, genome.getSecondary().getProductChances(), true, speed, prodMod, 1f);
+                    extendBeeYieldMap(yields, genome.getPrimary().getSpecialtyChances(), false, speed, prodMod, 1f);
+                    TreeMap<Float, ItemStack[]> productsByYield = new TreeMap<>();
+                    for (Map.Entry<ItemStack, Float> product : yields.entrySet()) {
+                        float chance = product.getValue();
+                        ItemStack item = product.getKey();
+                        if (productsByYield.computeIfPresent(
+                                chance,
+                                (_chance, items) -> items.length > 1 ? items : new ItemStack[] { items[0], item })
+                                == null) {
+                            productsByYield.put(chance, new ItemStack[] { item });
+                        }
+                    }
+
+                    NBTTagList tagList = new NBTTagList();
+                    for (Map.Entry<Float, ItemStack[]> ent : productsByYield.descendingMap().entrySet()) {
+                        String name = ent.getValue()[0].getUnlocalizedName();
+                        boolean isDup = ent.getValue().length > 1;
+                        NBTTagCompound entTag = new NBTTagCompound();
+                        entTag.setString("name", name);
+                        entTag.setBoolean("dup", isDup);
+                        entTag.setFloat("yield", ent.getKey());
+                        tagList.appendTag(entTag);
+                    }
+
+                    tag.setTag(BEE_YIELD, tagList);
                 }
             }
         }

--- a/src/main/resources/assets/wailaplugins/lang/en_US.lang
+++ b/src/main/resources/assets/wailaplugins/lang/en_US.lang
@@ -48,6 +48,7 @@ wp.hud.msg.breedProgress=Work Progress: %s
 wp.hud.msg.breedError=Error: %s
 
 wp.hud.msg.effectiveProductionMul=Effective Production: %s
+wp.hud.msg.revealYield=Hold Shift to see expected yields
 wp.hud.msg.yieldPerHour=per hour
 
 wp.hud.msg.queen=Queen

--- a/src/main/resources/assets/wailaplugins/lang/en_US.lang
+++ b/src/main/resources/assets/wailaplugins/lang/en_US.lang
@@ -48,6 +48,7 @@ wp.hud.msg.breedProgress=Work Progress: %s
 wp.hud.msg.breedError=Error: %s
 
 wp.hud.msg.effectiveProductionMul=Effective Production: %s
+wp.hud.msg.yieldPerHour=per hour
 
 wp.hud.msg.queen=Queen
 wp.hud.msg.princess=Princess

--- a/src/main/resources/assets/wailaplugins/lang/en_US.lang
+++ b/src/main/resources/assets/wailaplugins/lang/en_US.lang
@@ -48,8 +48,10 @@ wp.hud.msg.breedProgress=Work Progress: %s
 wp.hud.msg.breedError=Error: %s
 
 wp.hud.msg.effectiveProductionMul=Effective Production: %s
-wp.hud.msg.revealYield=Hold Shift to see expected yields
+wp.hud.msg.revealYield=Hold Shift for expected Jubilant yields
 wp.hud.msg.yieldPerHour=per hour
+wp.hud.msg.isJubilant=Is Jubilant
+wp.hud.msg.isBotJubilant=Is not Jubilant
 
 wp.hud.msg.queen=Queen
 wp.hud.msg.princess=Princess


### PR DESCRIPTION
Now apiaries will directly tell the player the expected amount of each product instead of just throwing math at them.

The "Expected Production" formula is still displayed, but now it turns red if the production modifier is high enough to cause pristine bees to become ignoble.

![new_hud](https://github.com/user-attachments/assets/1ff941ad-d702-4326-a153-8231f76cba7b)

Example with botanic bees since they have the most products.  Notice that all the petals have the same expected yield so they just get combined with "...".

(I already changed the "Hold shift" part to be italic and chevroned like the existing one)

Once the format is good, I'll add this to the iapiary too since it generate its tooltips differently