### PR TITLE
Fix typo in lang file for Forestry apiaries

### DIFF
--- a/src/main/resources/assets/wailaplugins/lang/en_US.lang
+++ b/src/main/resources/assets/wailaplugins/lang/en_US.lang
@@ -51,7 +51,7 @@ wp.hud.msg.effectiveProductionMul=Effective Production: %s
 wp.hud.msg.revealYield=Hold Shift for expected Jubilant yields
 wp.hud.msg.yieldPerHour=per hour
 wp.hud.msg.isJubilant=Is Jubilant
-wp.hud.msg.isBotJubilant=Is not Jubilant
+wp.hud.msg.isNotJubilant=Is not Jubilant
 
 wp.hud.msg.queen=Queen
 wp.hud.msg.princess=Princess


### PR DESCRIPTION
A simple one-char typo fix which allows the correct message to be shown.

Current behavior:
![image](https://github.com/user-attachments/assets/5d84f2bb-ef47-453e-a6cd-ed8ef66496c3)
